### PR TITLE
Periodically update last_seen_at

### DIFF
--- a/tendrl/node_monitoring/central_store/__init__.py
+++ b/tendrl/node_monitoring/central_store/__init__.py
@@ -1,4 +1,5 @@
 from tendrl.commons import central_store
+from tendrl.commons.utils.time_utils import now as tendrl_now
 
 
 class NodeMonitoringEtcdCentralStore(central_store.EtcdCentralStore):
@@ -10,3 +11,9 @@ class NodeMonitoringEtcdCentralStore(central_store.EtcdCentralStore):
 
     def save_definition(self, definition):
         NS.etcd_orm.save(definition)
+
+    def update_last_seen_at(self):
+        NS.etcd_orm.client.write(
+            '/monitoring/nodes/%s/last_seen_at' % NS.node_context.node_id,
+            tendrl_now().isoformat()
+        )

--- a/tendrl/node_monitoring/manager/__init__.py
+++ b/tendrl/node_monitoring/manager/__init__.py
@@ -6,6 +6,7 @@ from tendrl.commons import TendrlNS
 from tendrl.node_monitoring.central_store \
     import NodeMonitoringEtcdCentralStore
 from tendrl.node_monitoring import NodeMonitoringNS
+from tendrl.node_monitoring.sync import NodeMonitoringSyncStateThread
 
 
 class NodeMonitoringManager(commons_manager.Manager):
@@ -14,7 +15,7 @@ class NodeMonitoringManager(commons_manager.Manager):
             NodeMonitoringManager,
             self
         ).__init__(
-            None,
+            NS.state_sync_thread,
             NS.central_store_thread
         )
 
@@ -27,6 +28,7 @@ def main():
     complete = gevent.event.Event()
     NS.central_store_thread = NodeMonitoringEtcdCentralStore()
 
+    NS.state_sync_thread = NodeMonitoringSyncStateThread()
     NS.node_monitoring.definitions.save()
     NS.node_monitoring.config.save()
     NS.publisher_id = "node_monitoring"

--- a/tendrl/node_monitoring/sync/__init__.py
+++ b/tendrl/node_monitoring/sync/__init__.py
@@ -1,0 +1,12 @@
+from tendrl.commons.sds_sync import StateSyncThread
+import gevent
+
+
+class NodeMonitoringSyncStateThread(StateSyncThread):
+    def __init__(self):
+        super(NodeMonitoringSyncStateThread, self).__init__()
+
+    def _run(self):
+        while not self._complete.is_set():
+            NS.central_store_thread.update_last_seen_at()
+            gevent.sleep(3)


### PR DESCRIPTION
This is used by performance_monitoring to know the node status

Signed-off-by: anmolbabu <anmolbudugutta@gmail.com>